### PR TITLE
Allow processed source files to be exportable

### DIFF
--- a/lib/decorate.js
+++ b/lib/decorate.js
@@ -21,6 +21,7 @@ module.exports = function(context, file, options) {
 
     return lines;
   } else {
+    if (file.indexOf('app/assets') !== -1) { options.module = true; }
     file = path.relative(context, file);
     file = importsDecorator(file, options);
     file = requireDecorator(file);

--- a/lib/decorate.js
+++ b/lib/decorate.js
@@ -5,7 +5,8 @@ var requireDecorator = require('./decorators/require.js');
 
 var pathIndication = 'assets/javascripts';
 
-module.exports = function(context, file, options =  {}) {
+module.exports = function(context, file, options) {
+  options = options || {};
   if (/.eco$/.exec(file)) {
     // There is a better way to do this...
     // - get root path for rails javascript assets from context

--- a/lib/decorators/imports.js
+++ b/lib/decorators/imports.js
@@ -1,7 +1,8 @@
 var path = require('path');
 var importsLoader = require.resolve('imports-loader');
 
-module.exports = function importsDecorator(file, bypass = {}) {
+module.exports = function importsDecorator(file, bypass) {
+  bypass = bypass || {};
   var defaults = {
     define: undefined,
     exports: undefined,
@@ -13,7 +14,7 @@ module.exports = function importsDecorator(file, bypass = {}) {
   var imports = Object.keys(defaults)
     .filter(function (name) { return !bypass[name]; })
     .map(function(name) { return name + '=>' + defaults[name] })
-    .join(',')
+    .join(',');
 
   return importsLoader + '?' + imports + '!./' + file;
 };


### PR DESCRIPTION
Target inferred files that are non-vendor assets so we can require them in application + test code.

@juanca thoughts?
- [x] Bump alpha version on npm
