### PR TITLE
Allow optional env for gem paths

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -1,7 +1,10 @@
 var parsers = require('./directive-parsers.js');
 var transformers = require('./directive-transformers.js');
 
-require('./utils/bundler-check.js')();
+// Avoid using `bundle` inside webpack by passing all gem paths as an env
+if (!process.env.IMPORTANT_JS_GEM_PATHS) {
+  require('./utils/bundler-check.js')();
+}
 
 module.exports = function(source) {
   this.cacheable();

--- a/lib/transformers/require.js
+++ b/lib/transformers/require.js
@@ -34,8 +34,13 @@ function getGemAssetPath(requireFile) {
   var gem, assetPath;
   [gem, ...assetPath] = requireFile.split('/');
 
-  var gemPath = childProcess.spawnSync('bundle', ['show', gem]).output[1].toString().trim();
-
+  if (process.env.IMPORTANT_JS_GEM_PATHS)
+    // Avoid using `bundle` inside webpack by passing all gem paths as an env
+    var gemPath = process.env.IMPORTANT_JS_GEM_PATHS.split(':').find(function(path) {
+      return path.split('/').pop().indexOf(gem) > -1;
+    });
+  else
+    var gemPath = childProcess.spawnSync('bundle', ['show', gem]).output[1].toString().trim();
 
   var gemPaths = [
     path.join(gemPath, vendorPath, ...assetPath),

--- a/lib/utils/bundler-check.js
+++ b/lib/utils/bundler-check.js
@@ -1,9 +1,11 @@
 module.exports = function() {
-  var bundleCheck = require('child_process').spawnSync('bundle', ['check']).output.slice(1)
-  .map(function(buffer) { return buffer.toString(); })
-  .join('\n');
+  var bundleCheck = require('child_process').spawnSync('bundle', ['check']);
 
-  if (bundleCheck.indexOf('The Gemfile\'s dependencies are satisfied') === -1) {
-    throw new Error(bundleCheck || 'Bundler is not configured.');
+  var output = bundleCheck.output.slice(1)
+    .map(function(buffer) { return buffer.toString(); })
+    .join('\n');
+
+  if (bundleCheck.error) {
+    throw new Error(output || 'Bundler is not properly configured (No error description)');
   }
 };

--- a/lib/utils/bundler-check.js
+++ b/lib/utils/bundler-check.js
@@ -5,7 +5,7 @@ module.exports = function() {
     .map(function(buffer) { return buffer.toString(); })
     .join('\n');
 
-  if (bundleCheck.error) {
-    throw new Error(output || 'Bundler is not properly configured (No error description)');
+  if (bundleCheck.indexOf('The Gemfile\'s dependencies are satisfied') === -1) {
+    throw new Error(output || 'Bundler is not properly configured (and has no error description)');
   }
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sprockets-preloader",
-  "version": "0.9.9a",
+  "version": "0.9.10a",
   "description": "Webpack pre-loader to easily translate sprockets require directives into JavaScript module dependencies",
   "keywords": ["webpack", "loader", "rails", "sprockets", "directives", "require", "require_tree", "require_directory", "require_self"],
   "main": "lib/loader.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sprockets-preloader",
-  "version": "0.9.8a",
+  "version": "0.9.9a",
   "description": "Webpack pre-loader to easily translate sprockets require directives into JavaScript module dependencies",
   "keywords": ["webpack", "loader", "rails", "sprockets", "directives", "require", "require_tree", "require_directory", "require_self"],
   "main": "lib/loader.js",


### PR DESCRIPTION
This PR introduces a way to optionally avoid using `bundle`r inside this loader. By passing in any `IMPORTANT_JS_GEM_PATHS` environment variable, the loader can avoid spawning any `bundle show` processes. 

This is helpful when using, say, Circle CI without cache. Apparently, Circle CI will strip the gem / bundler environment variables when invoking webpack from rails (e.g. `rake webpack:compile` from webpack-rails).
