### PR TITLE
Update require.js

### DIFF
--- a/lib/transformers/require.js
+++ b/lib/transformers/require.js
@@ -2,6 +2,8 @@ var path = require('path');
 var childProcess = require('child_process');
 
 var decorate = require('../decorate.js');
+var requireDecorator = require('../decorators/require.js');
+
 var { fileExists, resolveFilePath } = require('../utils.js');
 
 var vendorPath = 'vendor/assets/javascripts';
@@ -70,6 +72,6 @@ module.exports = function requireTransformer(context, requireFile) {
   var gemAsset = getGemAssetPath(requireFile);
   if (gemAsset) return decorate(context, gemAsset, { require: true });
 
-  console.log('FILE UNRESOLVED:', context, requireFile);
-  return ''; // Unknown file: perhaps a weird gem require or it's just missing
+  // default require. Will most likely raise an error in webpack's resolver
+  return requireDecorator(requireFile);
 };


### PR DESCRIPTION
this is a WIP, untested. curious if this seems like a good change or not. I think it could make require errors more visible while migrating assets to webpack from sprockets. 

The current way of quietly logging to STDOUT I don't think is sufficient for compile errors having to do with unresolved sprockets paths. There is also the possibility that simply requiring the path could allow it to get successfully resolved by webpack.
